### PR TITLE
fix deprecation for Rails 5.x

### DIFF
--- a/lib/redmine_hangouts_chat_integration/issue_relations_controller_patch.rb
+++ b/lib/redmine_hangouts_chat_integration/issue_relations_controller_patch.rb
@@ -9,8 +9,8 @@ module RedmineHangoutsChatIntegration
       ## Same as typing in the class
       base.class_eval do
         unloadable
-        after_filter :after_action_create, :only => :create
-        after_filter :after_action_destroy, :only => :destroy
+        after_action :after_action_create, :only => :create
+        after_action :after_action_destroy, :only => :destroy
       end
     end
 


### PR DESCRIPTION
## testing environment information

```
[root@redmine redmine]# ruby -v
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]
[root@redmine redmine]# bundle exec rails -v
Rails 5.2.3
```
